### PR TITLE
Form input naming

### DIFF
--- a/back_end_development/add_todos_to_the_database_with_an_html_form.md
+++ b/back_end_development/add_todos_to_the_database_with_an_html_form.md
@@ -64,7 +64,7 @@ Finally, we create a view file named new.html.erb in the ***app/views/todo*** di
 
 <form action="#">
   <input class="text-input" id="new-todo-description" name="description" type="text" placeholder="Add a new todo...">
-  <input class="text-input" id="new-pomodoro-estimate" name="pomodoro-estimate" type="number" placeholder="Pomodoro estimate...">
+  <input class="text-input" id="new-pomodoro-estimate" name="pomodoro_estimate" type="number" placeholder="Pomodoro estimate...">
   <input class="button" id="add-new-todo-button" type="submit" value="Add todo">
 </form>
 ```

--- a/back_end_development/edit_update_and_delete.md
+++ b/back_end_development/edit_update_and_delete.md
@@ -32,7 +32,7 @@ Now we want to display a form that allows the user to edit the todo in the datab
 
   <form action="#">
     <input class="text-input" name="description" type="text" value="<%= @todo.description %>">
-    <input class="text-input" name="pomodoro-estimate" type="number" value="<%= @todo.pomodoro_estimate %>">
+    <input class="text-input" name="pomodoro_estimate" type="number" value="<%= @todo.pomodoro_estimate %>">
     <input class="button add-new-todo-button" type="submit" value="Edit todo">
     <a href="/todo/index" class="simple-link">Go back...</a>
   </form>


### PR DESCRIPTION
This past weekend my students found that, when creating Todos using their `new.html.erb` forms, they were creating Todos with a pomodoro estimate of `nil`. We realized that this was happening because the form was sending the pomodoro estimate as `pomodoro-estimate` but the controller code was expecting the estimate to appear in the params hash under `pomodoro_estimate`.

This PR changes both the `new.html.erb` form and the `edit.html.erb` form so that the estimate is sent up as `pomodoro_estimate` instead of `pomodoro-estimate`. We could instead change the controller code so that it accesses the estimate using `pomodoro-estimate`, but I think this is the more conventional approach—when you use Rails [form helpers](http://guides.rubyonrails.org/form_helpers.html#helpers-for-generating-form-elements) to generate input elements, for example, the generated name attributes (when they have more than one word) have underscores and not hyphens.