### PR TITLE
Add warning about Heroku git remote issue

### DIFF
--- a/workspace_and_account_setup/deploy_to_heroku.md
+++ b/workspace_and_account_setup/deploy_to_heroku.md
@@ -26,6 +26,9 @@ After you authenticate Heroku in Cloud9, they should see a message in the termin
 ## Create your first Heroku application from the command line
 Now that your Heroku account is connected to your Cloud9 workspace let's create your first Heroku application.
 
+_You must be in the root directory of your application for this next command to
+work properly._ The root directory should be `~/workspace`.
+
 Enter the following command into the command line replacing yourfirstname with your first name:
 ```shell
 $ heroku create yourfirstname-todo-app


### PR DESCRIPTION
It looks like Heroku only automatically creates a git remote if `heroku create` is run in the directory containing the `.git` directory.

If `heroku create` is run in a different directory, even one tracked by git but not at the top level, then the remote has to be manually created.

So this PR adds a warning about moving to the root directory of the application before running `heroku create`.

@harshamurthy 