### PR TITLE
fix gist link, add destroy link and root section [Update HTML href's that use a relative path]

### DIFF
--- a/back_end_development/edit_update_and_delete.md
+++ b/back_end_development/edit_update_and_delete.md
@@ -115,7 +115,19 @@ After the Todo object has been updated, the action redirects to the todo's show 
 Test it out to see if it works!
 
 ## Destroy
-Finally, we want to be able to destroy todos that we don't want. The destroy action is much simpler than the others. We want to be able to click the destroy `<a></a>` link on the todo's show page. We still need the **RCA** flow.
+Finally, we want to be able to destroy todos that we don't want. The destroy action is much simpler than the others. We want to be able to click the destroy `<a></a>` link on the todo's show page. 
+
+In the show.html.erb file we want to replace the following line:
+```html.erb
+<a href="#" class="button  delete-todo-button">Delete</a>
+```
+
+with this line:
+```html.erb
+<a href="/todo/destroy/<%= @todo.id %>" class="button delete-todo-button">Delete</a>
+```
+
+We still need the **RCA** flow.
 
 ### Route
 We want to create a route for the destroy action. When Rails goes to this route, it will trigger the destroy action and then redirects to the index page again, since the show page for the deleted todo no longer exists.

--- a/back_end_development/install_postgres.md
+++ b/back_end_development/install_postgres.md
@@ -38,11 +38,11 @@ Wait patiently after running the bundle install command. It may take a few minut
 
 In your file tree locate a file called database.yml. It will be located at todo_app/config/database.yml. Delete all the contents of your database.yml file and replace it with the code from the file I am going to share with you now.
 
->Share this [database.yml gist](https://gist.github.com/harshamurthy/7bdd2aa91d9232d591424794e6d8ce04 "database.yml") with your students.
+>Share this [database.yml gist](https://gist.githubusercontent.com/harshamurthy/7bdd2aa91d9232d591424794e6d8ce04/raw/dfb421e2184a3eaae3536a2bb2e3b931bcc84a98/database.yml "database.yml") with your students.
 
 Make sure to save the new contents of your database.yml file. Now you are going to enter in two commands in the command line that will set up your Postgres database and get it running.
 
->Make sure your students have properly replaced the stock database.yml contents with the contents found in the linked gist.
+>Make sure your students have properly replaced the stock database.yml contents with the contents found in the linked gist, keeping the same exact text alignment/tabs.
 
 Enter the following two commands into the command line, one at a time:
 ```Shell

--- a/back_end_development/the_root_route.md
+++ b/back_end_development/the_root_route.md
@@ -30,6 +30,22 @@ root to: 'todo#index'
 
 As you can see above, when defining the root route, we don't define the part that we add to the end of the URL. This is because the root route is always represented by a forward slash `/`.
 
+***Update HTML href's that use a relative path***
+
+An absolute file path is the full URL to a file, e.g.
+```HTML
+<img src="https://www.w3schools.com/images/picture.jpg" alt="Mountain">
+```
+
+If your index.html.erb file has an href like this to link to the Show page, then the href is not an absolute path but a relative path, meaning relative to the current folder, which was /todo when our web site url ended in /todo/index. 
+```HTML
+<a href="show/<%= todo.id %>"><%= todo.description %></a>
+```
+But current folder is now the root, i.e. /, due to our above change. So you'll need to change href like so: 
+```HTML
+<a href="/todo/show/<%= todo.id %>"><%= todo.description %></a>
+```
+
 The final step is to go through the various files in your app and change `todo/index` to `/`.
 
 ## Commit and Push to GitHub


### PR DESCRIPTION
fix gist link so copy/paste preserves all tabs/indenting and add tab warning, otherwise 'rails generate model Todo description:string pomodoro_estimate:integer complete:boolean' will fail

link destroy in show.html.erb
@harshamurthy @ssapra 